### PR TITLE
Remove irrelavant config from TLS encryption section

### DIFF
--- a/.connector-store/meta.json
+++ b/.connector-store/meta.json
@@ -17,7 +17,7 @@
     ],
     "releases": [
         {
-            "tagName": "v0.9.0",
+            "tagName": "v0.9.1",
             "products": [
                 "MI 4.4.0"
             ],

--- a/src/main/assembly/zip-assembly.xml
+++ b/src/main/assembly/zip-assembly.xml
@@ -42,10 +42,5 @@
             <source>src/main/resources/connector.xml</source>
             <outputDirectory>/</outputDirectory>
         </file>
-<!--        <file>-->
-<!--            <source>src/main/resources/descriptor.yml</source>-->
-<!--            <outputDirectory>/</outputDirectory>-->
-<!--            <filtered>true</filtered>-->
-<!--        </file>-->
     </files>
 </assembly>

--- a/src/main/java/org/wso2/integration/inbound/PulsarMessageConsumer.java
+++ b/src/main/java/org/wso2/integration/inbound/PulsarMessageConsumer.java
@@ -56,7 +56,6 @@ import java.io.InputStream;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Properties;
-import java.util.SortedMap;
 import java.util.concurrent.ArrayBlockingQueue;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutorService;
@@ -669,7 +668,14 @@ public class PulsarMessageConsumer extends GenericPollingConsumer {
      */
     private boolean isRollback(MessageContext msgCtx) {
         // check rollback property from synapse context
-        Object rollbackProp = msgCtx.getProperty("SET_ROLLBACK_ONLY");
+        Object rollbackProp = msgCtx.getProperty(PulsarConstants.SET_ROLLBACK_ONLY);
+        if (rollbackProp == null) {
+            // check rollback property from operation context in axis2 message context
+            org.apache.axis2.context.MessageContext axis2MessageCtx =
+                    ((Axis2MessageContext) msgCtx).getAxis2MessageContext();
+            rollbackProp = axis2MessageCtx.getOperationContext().getProperty(PulsarConstants.SET_ROLLBACK_ONLY);
+        }
+
         if (rollbackProp != null) {
             return (rollbackProp instanceof Boolean && ((Boolean) rollbackProp))
                     || (rollbackProp instanceof String && Boolean.valueOf((String) rollbackProp));

--- a/src/main/java/org/wso2/integration/inbound/connection/PulsarConnectionSetup.java
+++ b/src/main/java/org/wso2/integration/inbound/connection/PulsarConnectionSetup.java
@@ -86,9 +86,6 @@ public class PulsarConnectionSetup {
         if (secureConfig.getTlsTrustStoreType() != null) {
             clientBuilder.tlsTrustStoreType(secureConfig.getTlsTrustStoreType());
         }
-        if (secureConfig.getAutoCertRefreshSeconds() != null) {
-            clientBuilder.autoCertRefreshSeconds(secureConfig.getAutoCertRefreshSeconds());
-        }
 
         return clientBuilder;
     }

--- a/src/main/java/org/wso2/integration/inbound/pojo/PulsarSecureConnectionConfig.java
+++ b/src/main/java/org/wso2/integration/inbound/pojo/PulsarSecureConnectionConfig.java
@@ -34,7 +34,6 @@ public class PulsarSecureConnectionConfig extends PulsarConnectionConfig {
     private String tlsTrustStorePath;
     private String tlsTrustStorePassword;
     private String tlsTrustStoreType;
-    private Integer autoCertRefreshSeconds;
 
     public Boolean useTls() {
         return useTls;
@@ -137,16 +136,6 @@ public class PulsarSecureConnectionConfig extends PulsarConnectionConfig {
     public void setTlsTrustStoreType(String tlsTrustStoreType) {
         if (StringUtils.isNotEmpty(tlsTrustStoreType)) {
             this.tlsTrustStoreType = tlsTrustStoreType;
-        }
-    }
-
-    public Integer getAutoCertRefreshSeconds() {
-        return autoCertRefreshSeconds;
-    }
-
-    public void setAutoCertRefreshSeconds(String autoCertRefreshSeconds) {
-        if (StringUtils.isNotEmpty(autoCertRefreshSeconds)) {
-            this.autoCertRefreshSeconds = Integer.parseInt(autoCertRefreshSeconds);
         }
     }
 

--- a/src/main/java/org/wso2/integration/inbound/utils/PulsarConstants.java
+++ b/src/main/java/org/wso2/integration/inbound/utils/PulsarConstants.java
@@ -74,7 +74,6 @@ public class PulsarConstants {
     public static final String AUTH_PARAM_MAP = "authParamMap";
     public static final String AUTH_PARAMS = "authParams";
     public static final String AUTH_PLUGIN_CLASS_NAME = "authPluginClassName";
-    public static final String AUTO_CERT_REFRESH_SECONDS = "autoCertRefreshSeconds";
     public static final String JWT_TOKEN = "jwtToken";
 
     public static final String TOPIC_NAMES = "topicNames";
@@ -120,5 +119,7 @@ public class PulsarConstants {
     public static final String MSG_ID = "messageId";
     public static final String KEY = "key";
     public static final String REDELIVERY_COUNT = "redeliveryCount";
+
+    public static final String SET_ROLLBACK_ONLY = "SET_ROLLBACK_ONLY";
 
 }

--- a/src/main/java/org/wso2/integration/inbound/utils/PulsarUtils.java
+++ b/src/main/java/org/wso2/integration/inbound/utils/PulsarUtils.java
@@ -93,7 +93,6 @@ public class PulsarUtils {
         config.setTlsTrustStorePath(properties.getProperty(PulsarConstants.TLS_TRUST_STORE_PATH));
         config.setTlsTrustStorePassword(properties.getProperty(PulsarConstants.TLS_TRUST_STORE_PASSWORD));
         config.setTlsTrustStoreType(properties.getProperty(PulsarConstants.TLS_TRUST_STORE_TYPE));
-        config.setAutoCertRefreshSeconds(properties.getProperty(PulsarConstants.AUTO_CERT_REFRESH_SECONDS));
 
         return config;
     }

--- a/src/main/resources/uischema.json
+++ b/src/main/resources/uischema.json
@@ -295,23 +295,6 @@
                 {
                   "type": "attribute",
                   "value": {
-                    "name": "autoCertRefreshSeconds",
-                    "displayName": "Auto Certificate Refresh Interval (in seconds)",
-                    "inputType": "string",
-                    "validateType": "number",
-                    "defaultValue": "",
-                    "required": "false",
-                    "helpTip": "Interval in seconds to automatically refresh TLS certificates.",
-                    "enableCondition": [
-                      {
-                        "tlsAllowInsecureConnection": "false"
-                      }
-                    ]
-                  }
-                },
-                {
-                  "type": "attribute",
-                  "value": {
                     "name": "enableTlsHostnameVerification",
                     "displayName": "Enable TLS Hostname Verification",
                     "inputType": "boolean",


### PR DESCRIPTION
## Purpose
The parameter `autoCertRefreshSeconds` is not relevant for TLS encryption. Hence, removing.